### PR TITLE
Allow using `setup.cfg` and a relative repo root path

### DIFF
--- a/git_notion/git_notion.py
+++ b/git_notion/git_notion.py
@@ -55,7 +55,7 @@ def upload_file(base_page, filename: str, page_title=None):
 def sync_to_notion(repo_root: str = "."):
     os.chdir(repo_root)
     config = ConfigParser()
-    config.read(os.path.join(repo_root, "setup.cfg"))
+    config.read("setup.cfg")
     repo_name = os.path.basename(os.getcwd())
 
     root_page_url = os.getenv("NOTION_ROOT_PAGE") or config.get('git-notion', 'notion_root_page')


### PR DESCRIPTION
This works because the current directory is already changed just before loading the config.