### PR TITLE
Enable configurable Github folder <> Notion subpage URL mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ cd git-notion
 pip install -e .
 ```
 
+To fix HTTP errors, then run:
+```python -m pip install notion-cobertos-fork```
+
 ## Configuring
 
 `NOTION_TOKEN_V2` - Can be found in your [browser cookies](https://www.redgregory.com/notion/2020/6/15/9zuzav95gwzwewdu1dspweqbv481s5) for Notion's website.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ ignore_regex = models/.*
 notion_root_page = https://www.notion.so/...
 ```
 
+If you want to map specific Github folders to Notion subpages besides the `notion_root_page`, you can add the folder names and subpage URLs as parameters in the `setup.cfg` for the repo:
+```
+[folders]
+# docs = <any_notion_url> # This can be any subpage of the Notion root page
+# docs/NestedTest = <any_other_notion_url> # This can be the same subpage as above, or any other subpage of the Notion root page
+```
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ cd git-notion
 pip install -e .
 ```
 
-To fix HTTP errors, then run:
-```python -m pip install notion-cobertos-fork```
-
 ## Configuring
 
 `NOTION_TOKEN_V2` - Can be found in your [browser cookies](https://www.redgregory.com/notion/2020/6/15/9zuzav95gwzwewdu1dspweqbv481s5) for Notion's website.

--- a/docs/NestedTest/TestDoc3.md
+++ b/docs/NestedTest/TestDoc3.md
@@ -1,2 +1,0 @@
-### Heading for Test
-Here's an example of a markdown file that's in a nested folder within the root folder 'docs'. I want to see if/how it gets picked up in Notion.

--- a/docs/NestedTest/TestDoc3.md
+++ b/docs/NestedTest/TestDoc3.md
@@ -1,0 +1,2 @@
+### Heading for Test
+Here's an example of a markdown file that's in a nested folder within the root folder 'docs'. I want to see if/how it gets picked up in Notion.

--- a/docs/NestedTest/nested_example.md
+++ b/docs/NestedTest/nested_example.md
@@ -1,0 +1,2 @@
+### Heading for Test
+Here's an example of a markdown file that's in a nested folder within the folder `docs`. We can also add the folder path `docs/NestedDocs` in  `setup.cfg` to pick up this file to the specified Notion URL.

--- a/docs/example.md
+++ b/docs/example.md
@@ -2,3 +2,5 @@ Example
 ==
 
 This is an example markdown file to sync.
+
+If you add the `docs` folder name to the [folders] config settings in `setup.cfg`, this file will sync to the specified Notion subpage URL.

--- a/docs/example.md
+++ b/docs/example.md
@@ -3,4 +3,4 @@ Example
 
 This is an example markdown file to sync.
 
-If you add the `docs` folder name to the [folders] config settings in `setup.cfg`, this file will sync to the specified Notion subpage URL.
+If you add the `docs` folder name to the `[folders]` config settings in `setup.cfg`, this file will sync to the specified Notion subpage URL.

--- a/git_notion/git_notion.py
+++ b/git_notion/git_notion.py
@@ -65,7 +65,6 @@ def sync_to_notion(repo_root: str = "."):
 
     for file in glob.glob("**/*.md", recursive=True):
         if ignore_regex is None or not re.match(ignore_regex, file):
-            print(file)
 
             # Extract folder from the file path
             folder = os.path.dirname(file)
@@ -73,6 +72,11 @@ def sync_to_notion(repo_root: str = "."):
             # Use folder-specific URL if available, otherwise use the default repo_page URL
             folder_url = config.get('folders', folder, fallback=None)
             upload_file(repo_page if folder_url is None else get_client().get_block(folder_url), file)
+            if folder_url:
+                print(file, "uploaded to: ", folder_url)
+            else:
+                print(file, "uploaded to: default repo page")
+
 
 
 # Example call:

--- a/git_notion/git_notion.py
+++ b/git_notion/git_notion.py
@@ -52,10 +52,10 @@ def upload_file(base_page, filename: str, page_title=None):
     return page
 
 
-def sync_to_notion(repo_root: str = ".", config_file_path: str = "notion_config.ini"):
+def sync_to_notion(repo_root: str = "."):
     os.chdir(repo_root)
     config = ConfigParser()
-    config.read(os.path.join(repo_root, config_file_path))
+    config.read(os.path.join(repo_root, "setup.cfg"))
     repo_name = os.path.basename(os.getcwd())
 
     root_page_url = os.getenv("NOTION_ROOT_PAGE") or config.get('git-notion', 'notion_root_page')

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,7 @@ collect_ignore = ['setup.py']
 
 [git-notion]
 notion_root_page = https://www.notion.so/Git-Documents-6cf97b2d7ab64a7d964c7a7bcc42f9aa
+
+[folders]
+# docs = <any_notion_url> # This can be any subpage of the Notion root page
+# docs/NestedTest = <any_other_notion_url> # This can be the same subpage as above, or any other subpage of the Notion root page


### PR DESCRIPTION
This feature addition enables the user to specify in `setup.cfg` a Github folder <> Notion URL mapping for as many Github folders or subfolders as desired. This way, they can mirror documentation organization in Github to subpage organization in Notion. You can also map Github folders from different repos to the same Notion subpage. 

Notes:
- Notion subpages must already be created, so you can access the URL
- Does not replace ignore_regex for folders that you do NOT want to upload to Notion. If the filename doesn't match one of the specified folders, then it will revert to the default behavior of uploading to the repo-specific page.
- If you still want all your .md files in one Notion page, you can leave the [folder] config blank and use the default behavior
